### PR TITLE
Fix _dir variable

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-mk
 	pkgdesc = ROS - A collection of .mk include files for building ROS architectural elements.
 	pkgver = 1.14.8
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/mk
 	arch = any
 	license = BSD

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,7 +27,7 @@ depends=(
 	${ros_depends[@]}
 )
 
-_dir="ros-${pkgver}/mk"
+_dir="ros-${pkgver}/core/mk"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/ros/archive/${pkgver}.tar.gz")
 sha256sums=('998c79df7d7ce015eee28fb768b28b68cc37a98b4a4b8daef16a1280cccb5bee')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/mk'
 pkgname='ros-melodic-mk'
 pkgver='1.14.8'
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(


### PR DESCRIPTION
Will not build like this:

```
==> Retrieving sources...
  -> Found ros-melodic-mk-1.14.8.tar.gz
==> WARNING: Skipping all source file integrity checks.
==> Extracting sources...
  -> Extracting ros-melodic-mk-1.14.8.tar.gz with bsdtar
==> Starting build()...
grep: /build/ros-melodic-mk/src/ros-1.14.8/mk: No such file or directory
CMake Error: The source directory "/build/ros-melodic-mk/src/ros-1.14.8/mk" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
==> ERROR: A failure occurred in build().
    Aborting...
```